### PR TITLE
Made processing an event consume self

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,5 @@
 use relay::Relay;
 
 pub trait Event<Context: Send> {
-    fn process(&self, relay: &Relay<Context>, ctx: &mut Context);
+    fn process(self: Box<Self>, relay: &Relay<Context>, ctx: &mut Context);
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -12,7 +12,7 @@ pub struct GenericEvent<Context, F>
 }
 
 impl<Context: Send, F: Fn(&Relay<Context>, &mut Context)> Event<Context> for GenericEvent<Context, F> {
-    fn process(&self, relay: &Relay<Context>, ctx: &mut Context) {
+    fn process(self: Box<Self>, relay: &Relay<Context>, ctx: &mut Context) {
         (self.handler)(relay, ctx);
     }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -22,7 +22,7 @@ struct IncrementEvent {
 
 // This is the handler of an event
 impl Event<TestContext> for IncrementEvent {
-    fn process(&self, _: &Relay<TestContext>, ctx: &mut TestContext) {
+    fn process(self: Box<Self>, _: &Relay<TestContext>, ctx: &mut TestContext) {
         ctx.counter += self.val;
     }
 }


### PR DESCRIPTION
This becomes very useful in part of Veloren's architecture due to the nature of the `.split()` method on the `Conn` object.